### PR TITLE
Add `StartupNotify`/`StartupWMClass` to desktop file

### DIFF
--- a/br.gov.fazenda.receita.irpf2022.desktop
+++ b/br.gov.fazenda.receita.irpf2022.desktop
@@ -7,3 +7,5 @@ Icon=br.gov.fazenda.receita.irpf2022
 Exec=irpf2022
 Categories=Network;
 Keywords=dirpf;imposto;irpf;receitanet;
+StartupNotify=true
+StartupWMClass=serpro-ppgd-app-IRPFPGD


### PR DESCRIPTION
Fixes window association issue that would prevent the app from being added to favorites.

Docs: https://specifications.freedesktop.org/desktop-entry-spec/1.5/ar01s06.html