### PR TITLE
Update x-checker-data URL for IRPF

### DIFF
--- a/br.gov.fazenda.receita.irpf2022.yaml
+++ b/br.gov.fazenda.receita.irpf2022.yaml
@@ -47,8 +47,8 @@ modules:
         sha256: be419e51a833112eca3b3c67cacdeaa3cc18e0026a18596a1dc197b00e9c8ede
         x-checker-data:
           type: html
-          url: https://www.gov.br/receitafederal/pt-br/centrais-de-conteudo/download/pgd/dirpf
-          version-pattern: /arquivos/IRPF2022-([\d.]+)\.zip
+          url: https://downloadirpf.receita.fazenda.gov.br/irpf/2022/irpf/update/latest.xml
+          version-pattern: <pkgver>([\d.]+)</pkgver>
           url-template: https://downloadirpf.receita.fazenda.gov.br/irpf/2022/irpf/arquivos/IRPF2022-$version.zip
           is-main-source: true
       - type: file


### PR DESCRIPTION
This URL is used internally by the app, so newer versions are published here first.